### PR TITLE
Refactor chat fetch into service module

### DIFF
--- a/renderer/chatService.js
+++ b/renderer/chatService.js
@@ -1,0 +1,11 @@
+export async function callChatApi(message) {
+  const res = await fetch('http://localhost:8080/chat', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ message }),
+  });
+  if (!res.ok) {
+    throw new Error(`HTTP ${res.status}`);
+  }
+  return res.json();
+}

--- a/renderer/renderer.js
+++ b/renderer/renderer.js
@@ -6,6 +6,7 @@ import {
   createNewFileInRoot,
   createNewDirInRoot,
 } from "./fileManager/fileManager.js";
+import { callChatApi } from "./chatService.js";
 function showToast(message, success = true) {
   const container = document.getElementById("toast-container");
   if (!container) return;
@@ -309,13 +310,6 @@ function initializeVoicePanel() {
         const sysLoaderId = addSystemMessageLoading();
 
         try {
-          const res = await fetch("http://localhost:8080/chat", {
-            method: "POST",
-            headers: { "Content-Type": "application/json" },
-            body: JSON.stringify({ message: transcription }),
-          });
-          if (!res.ok) throw new Error(`HTTP ${res.status}`);
-
           const {
             match,
             allParams,
@@ -323,7 +317,7 @@ function initializeVoicePanel() {
             groupKey,
             outParams,
             summary,
-          } = await res.json();
+          } = await callChatApi(transcription);
 
           console.log("--- ChatGPT Response ---");
           console.log({


### PR DESCRIPTION
## Summary
- extract the `/chat` service call to a new `chatService` module
- use `callChatApi` from `renderer.js`

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6840cf21bad48332b8ce6ebe5ed72ac6