### PR TITLE
Fix scroll clipping in embedded terminal

### DIFF
--- a/renderer/terminal/terminal.css
+++ b/renderer/terminal/terminal.css
@@ -5,11 +5,10 @@
         margin: 0;
         padding: 0;
       }
-      /* Se agrega padding interno para dar margen */
+      /* Contenedor de la terminal */
       #terminal-container {
         width: 100%;
         height: 100%;
-        padding: 8px;
         box-sizing: border-box;
         background-color: #1e1e1e;
         border: 1px solid #333;


### PR DESCRIPTION
## Summary
- update terminal container styles so the last output line is visible

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6847aa54d1a88332a9720f761a98abdf