### PR TITLE
Add light/dark theme toggle

### DIFF
--- a/renderer/index.css
+++ b/renderer/index.css
@@ -1,3 +1,19 @@
+:root {
+  --header-bg: linear-gradient(90deg, #23252d, #1f2128);
+  --central-bg: #1a1c21;
+  --divider-bg: #202228;
+  --voice-panel-bg: #2c2f36;
+  --voice-content-bg: #1d2026;
+}
+
+.light-mode {
+  --header-bg: linear-gradient(90deg, #f5f5f5, #e0e0e0);
+  --central-bg: #ffffff;
+  --divider-bg: #dcdcdc;
+  --voice-panel-bg: #f1f1f1;
+  --voice-content-bg: #ffffff;
+}
+
     /* Reset básico */
     html, body {
       height: 100%;
@@ -14,7 +30,7 @@
     /* Sidebar */
     .sidebar {
       width: 280px;
-      background-color: #1f2128;
+      background-color: var(--sidebar-bg);
       display: flex;
       flex-direction: column;
       padding: 10px;
@@ -56,7 +72,7 @@
       display: flex;
       flex-direction: column;
       overflow: hidden;
-      background-color: #1a1c21;
+      background-color: var(--central-bg);
       position: relative;
     }
     /* Editor de código: se usa el contenedor editorContainer */
@@ -65,12 +81,12 @@
       overflow: auto;
       padding: 10px;
       box-sizing: border-box;
-      background-color: #1a1c21;
+      background-color: var(--central-bg);
     }
     /* Divisor horizontal: fijo, con botón de toggle */
     .horizontal-divider {
       height: 5px;
-      background-color: #202228;
+      background-color: var(--divider-bg);
       position: relative;
       display: flex;
       align-items: center;
@@ -95,7 +111,7 @@
     /* Panel derecho: Voz */
     .voice-panel {
       width: 250px;
-      background-color: #2c2f36;
+      background-color: var(--voice-panel-bg);
       color: #f0f0f0;
       padding: 10px;
       box-sizing: border-box;
@@ -121,13 +137,13 @@
       border: 1px solid #555;
       border-radius: 4px;
       padding: 8px;
-      background-color: #1d2026;
+      background-color: var(--voice-content-bg);
     }
     .app-header {
     display: flex;
     align-items: center;
     padding: 8px 16px;
-      background: linear-gradient(90deg, #23252d, #1f2128); /* tono acorde al nuevo esquema */
+      background: var(--header-bg);
   }
 
   .app-icon {
@@ -141,6 +157,15 @@
     color: #FFF;
     font-size: 1.25rem;
     font-weight: 600;
+  }
+
+  #theme-toggle {
+    margin-left: auto;
+    background: none;
+    border: none;
+    color: inherit;
+    font-size: 1.2rem;
+    cursor: pointer;
   }
   #terminal-toggle-float {
   position: absolute;

--- a/renderer/index.css
+++ b/renderer/index.css
@@ -1,5 +1,6 @@
 :root {
   --header-bg: linear-gradient(90deg, #23252d, #1f2128);
+  --header-text-color: #ffffff;
   --central-bg: #1a1c21;
   --divider-bg: #202228;
   --voice-panel-bg: #2c2f36;
@@ -8,6 +9,7 @@
 
 .light-mode {
   --header-bg: linear-gradient(90deg, #f5f5f5, #e0e0e0);
+  --header-text-color: #111111;
   --central-bg: #ffffff;
   --divider-bg: #dcdcdc;
   --voice-panel-bg: #f1f1f1;
@@ -139,11 +141,12 @@
       padding: 8px;
       background-color: var(--voice-content-bg);
     }
-    .app-header {
+.app-header {
     display: flex;
     align-items: center;
     padding: 8px 16px;
-      background: var(--header-bg);
+    background: var(--header-bg);
+    color: var(--header-text-color);
   }
 
   .app-icon {
@@ -163,7 +166,8 @@
     margin-left: auto;
     background: none;
     border: none;
-    color: inherit;
+    padding: 4px;
+    color: var(--header-text-color);
     font-size: 1.2rem;
     cursor: pointer;
   }

--- a/renderer/index.html
+++ b/renderer/index.html
@@ -11,6 +11,7 @@
   <header class="app-header">
     <img src="../icon.png" alt="VoxCode Logo" class="app-icon">
     <h1 class="app-title">VoxCode</h1>
+    <button id="theme-toggle" class="theme-toggle-btn">🌙</button>
   </header>
   <div id="toast-container"></div>
   <div class="container">
@@ -156,6 +157,27 @@ fetch('voicePanel.html')
   })
   .catch(err => console.error('Error cargando panel de voz:', err));
 </script>
+
+  <script>
+    const themeToggle = document.getElementById('theme-toggle');
+    const body = document.body;
+    function applyTheme(theme) {
+      if (theme === 'light') {
+        body.classList.add('light-mode');
+        themeToggle.textContent = '🌙';
+      } else {
+        body.classList.remove('light-mode');
+        themeToggle.textContent = '☀️';
+      }
+    }
+    const savedTheme = localStorage.getItem('theme') || 'dark';
+    applyTheme(savedTheme);
+    themeToggle.addEventListener('click', () => {
+      const newTheme = body.classList.contains('light-mode') ? 'dark' : 'light';
+      localStorage.setItem('theme', newTheme);
+      applyTheme(newTheme);
+    });
+  </script>
 
 </body>
 </html>

--- a/renderer/styles.css
+++ b/renderer/styles.css
@@ -1,9 +1,25 @@
+  :root {
+    --bg-main: #181a1f;
+    --text-main: #e6e6e6;
+    --sidebar-bg: #1f2128;
+    --sidebar-text: #cfd6e1;
+    --sidebar-hover-bg: #2c2f36;
+  }
+
+  .light-mode {
+    --bg-main: #ffffff;
+    --text-main: #202020;
+    --sidebar-bg: #f2f2f2;
+    --sidebar-text: #202020;
+    --sidebar-hover-bg: #e0e0e0;
+  }
+
   body, html {
     margin: 0;
     padding: 0;
     font-family: 'Segoe UI', sans-serif;
-    background-color: #181a1f;
-    color: #e6e6e6;
+    background-color: var(--bg-main);
+    color: var(--text-main);
     height: 100vh;
   }
   
@@ -13,8 +29,8 @@
   }
   
   .sidebar {
-    background-color: #1f2128;
-    color: #cfd6e1;
+    background-color: var(--sidebar-bg);
+    color: var(--sidebar-text);
   }
   
   .sidebar button {
@@ -46,7 +62,7 @@
   }
   
   .sidebar li:hover {
-    background-color: #2a2d35;
+    background-color: var(--sidebar-hover-bg);
 }
   
   .sidebar li.active {
@@ -126,7 +142,7 @@
   
   /* mejorar selección en sidebar */
   .sidebar li:hover {
-    background-color: #2c2f36;
+    background-color: var(--sidebar-hover-bg);
     color: #FFF;
   }
   

--- a/renderer/terminal/index.html
+++ b/renderer/terminal/index.html
@@ -16,13 +16,20 @@
 
     <script>
       const { sendKeystroke, onIncomingData } = window.terminalAPI;
+      if (localStorage.getItem('theme') === 'light') {
+        document.documentElement.classList.add('light-mode');
+      }
+      window.addEventListener('storage', (e) => {
+        if (e.key === 'theme') location.reload();
+      });
 
       // Inicializamos la terminal y el FitAddon
+      const bg = getComputedStyle(document.documentElement).getPropertyValue('--terminal-bg').trim() || '#1e1e1e';
       const term = new Terminal({
         cursorBlink: true,
         fontFamily: "monospace",
         fontSize: 12,
-        theme: { background: "#1e1e1e", foreground: "#d4d4d4", cursor: "#D300F3FF" }
+        theme: { background: bg, foreground: "#d4d4d4", cursor: "#D300F3FF" }
       });
       const fitAddon = new window.FitAddon.FitAddon();
 

--- a/renderer/terminal/terminal.css
+++ b/renderer/terminal/terminal.css
@@ -1,3 +1,11 @@
+      :root {
+        --terminal-bg: #181a1f;
+      }
+
+      .light-mode {
+        --terminal-bg: #ffffff;
+      }
+
       html,
       body {
         width: 100%;
@@ -10,7 +18,7 @@
           width: 100%;
           height: 100%;
           box-sizing: border-box;
-          background-color: #181a1f;
+          background-color: var(--terminal-bg);
           border: 1px solid #444;
           border-radius: 6px;
           box-shadow: 0 0 6px rgba(0, 0, 0, 0.5);

--- a/renderer/voicePanel.css
+++ b/renderer/voicePanel.css
@@ -1,3 +1,15 @@
+:root {
+  --voice-panel-gradient: linear-gradient(145deg, rgba(50, 52, 58, 0.95), rgba(28, 30, 36, 0.95));
+  --voice-border-color: #353a45;
+  --voice-header-bg: rgba(255, 255, 255, 0.05);
+}
+
+.light-mode {
+  --voice-panel-gradient: linear-gradient(145deg, rgba(240,240,240,0.95), rgba(220,220,220,0.95));
+  --voice-border-color: #cccccc;
+  --voice-header-bg: rgba(0,0,0,0.05);
+}
+
 @keyframes icon-pulse {
   0%, 100% { transform: scale(1); }
   50% { transform: scale(1.2); }
@@ -16,8 +28,8 @@
 .voice-panel {
   width: 260px;
   height: 100vh;
-  background: linear-gradient(145deg, rgba(50, 52, 58, 0.95), rgba(28, 30, 36, 0.95));
-  border-left: 2px solid #353a45;
+  background: var(--voice-panel-gradient, linear-gradient(145deg, rgba(50, 52, 58, 0.95), rgba(28, 30, 36, 0.95)));
+  border-left: 2px solid var(--voice-border-color, #353a45);
   display: flex;
   flex-direction: column;
   padding: 16px;
@@ -37,8 +49,8 @@
   gap: 8px;
   margin-bottom: 8px;
   padding: 8px;
-  border-bottom: 1px solid #3a3f4b;
-  background: rgba(255, 255, 255, 0.05);
+  border-bottom: 1px solid var(--voice-border-color, #3a3f4b);
+  background: var(--voice-header-bg, rgba(255, 255, 255, 0.05));
   border-radius: 8px;
 }
 


### PR DESCRIPTION
## Summary
- add theme toggle button to header
- store theme preference in localStorage
- apply CSS variables for dark and light themes
- adjust terminal page to respect stored theme

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6847adbd16d483328d77758c47795b6f